### PR TITLE
feat: add okto eliza plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated list of awesome things related to <a href='https://github.com/elizaOS/
 - [plugin-tee-verfiable-log](https://github.com/elizaOS/eliza/tree/develop/packages/plugin-tee-verifiable-log) - Verifiable logging system using trusted execution environments
 - [plugin-thirdweb](https://github.com/elizaOS/eliza/tree/develop/packages/plugin-thirdweb) - Integration with ThirdWeb's web3 development platform
 - [plugin-spheron](https://github.com/elizaOS/eliza/tree/develop/packages/plugin-spheron) - Plugin for decentralized storage and deployment via Spheron
+- [plugin-okto](https://github.com/okto-hq/eliza-okto-plugin) - Plugin for integrating with Okto wallet
 
 ## Tools
 - [ElizaOS-starter](https://github.com/elizaOS/eliza-starter) - elizaOS starter template


### PR DESCRIPTION
This PR adds the ElizaOS Okto Plugin, a comprehensive integration for ElizaOS that enables seamless access to Okto's APIs and services. The plugin offers features that enhance ElizaOS's functionality, making it easier for users to interact with Okto platform