### PR TITLE
Add NewsRiver Eliza Plugin (x402 Native News Subscriptions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ A curated list of awesome things related to the [eliza framework](https://github
 - [Bittensor](https://github.com/elizaos-plugins/plugin-bittensor) - Integration with BitMind's API for accessing AI services on Bittensor
 - [Devin](https://github.com/elizaos-plugins/plugin-devin) - Integration with Devin API for automated engineering assistance
 - [Isaacx](https://github.com/isaacx0/plugin-isaacx) - Advanced AI reasoning and cognitive modeling plugin
+- [NewsRiver](https://github.com/newsriver/eliza-plugin) - Provide your agent with a daily "News Subscription." Connects Eliza to the NewsRiver Intelligence API for daily, Gemini-synthesized macro and crypto briefings. Supports native x402 USDC micropayments.
 - [Mind Network](https://github.com/elizaos-plugins/plugin-mind-network) - Integration with Mind Network Hubs for secure, privacy-preserving voting
 - [NVIDIA NIM](https://github.com/elizaos-plugins/plugin-nvidia-nim) - NVIDIA's AI foundation models for content analysis and safety checks
 - [OpenAI](https://github.com/elizaos-plugins/plugin-openai) - Integration with OpenAI's GPT models for automated text generation


### PR DESCRIPTION
Hey! I'd like to add the `@newsriver/eliza-plugin` to the list. We noticed a gap where trading agents and research bots were struggling to parse raw RSS feeds effectively. This plugin connects agents to the NewsRiver API, which acts like a "Daily Newsletter for Agents." It provides structured, pre-synthesized JSON reports of the day's macro and crypto news (scored by Gemini 2.5). More importantly, it natively supports the **x402 protocol**. Developers don't need to sign up for an API key; their agent can simply use its Base wallet to pay $0.10 USDC synchronously per daily report.