### PR TITLE
Add swarms-x402 (SwarmX) plugin to AI & Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A curated list of awesome things related to the [eliza framework](https://github
 - [LLaMA](https://github.com/elizaos-plugins/plugin-llama) - Local LLM capabilities using LLaMA models with CPU and GPU support
 - [D.a.t.a](https://github.com/carv-protocol/plugin-d.a.t.a) - Data processing with authentication and trust scoring
 - [AlphaNeural](https://github.com/alphaneuralai/plugin-alphaneural) - Neural network capabilities for AI agents
+- [x402 + Swarms (SwarmX)](https://github.com/ItachiDevv/eliza-x402-swarms) - Multi-agent AI orchestration with x402 micropayments. 47 endpoints for contract audits, DeFi risk scoring, code audits, research reports. 15+ swarm architectures, 39 MCP tools. Pay per call with USDC.
 
 ### 🎨 Media & Content
 


### PR DESCRIPTION
## Summary

Adding the **x402+Swarms (SwarmX)** plugin to the AI & Data section of Plugins.

SwarmX is an ElizaOS v2 plugin (`@itachisol/plugin-x402-swarms`) that adds:
- **x402 micropayment integration** — automatic HTTP 402 pay-and-retry for USDC payments
- **Swarms multi-agent orchestration** — 15+ swarm architectures
- **47 HTTP endpoints** — contract audits, DeFi risk scoring, code audits, research reports, compliance
- **39 MCP tools** for AI agent discovery
- **5 actions, 4 services, 2 providers, 1 evaluator** (standard ElizaOS plugin structure)

Also works as a standalone HTTP server without ElizaOS.

- GitHub: https://github.com/ItachiDevv/eliza-x402-swarms
- npm: https://www.npmjs.com/package/@itachisol/plugin-x402-swarms
- ElizaOS plugin registry PR: https://github.com/elizaos-plugins/registry/pull/322