### PR TITLE
Add SwarmX (swarms-x402) plugin to AI & Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ A curated list of awesome things related to the [eliza framework](https://github
 - [LLaMA](https://github.com/elizaos-plugins/plugin-llama) - Local LLM capabilities using LLaMA models with CPU and GPU support
 - [D.a.t.a](https://github.com/carv-protocol/plugin-d.a.t.a) - Data processing with authentication and trust scoring
 - [AlphaNeural](https://github.com/alphaneuralai/plugin-alphaneural) - Neural network capabilities for AI agents
+- [SwarmX (swarms-x402)](https://github.com/SolTwizzy/swarms-x402) - Multi-agent AI orchestration with native x402 micropayments on Solana. 49 endpoints, 39 MCP tools, dual LLM (Gemini + OpenAI), knowledge/RAG with pgvector. ElizaOS v2 plugin.
+
 
 ### 🎨 Media & Content
 


### PR DESCRIPTION
## SwarmX (swarms-x402)

Multi-agent AI orchestration with native x402 micropayments on Solana.

- **49 x402-gated endpoints** on Solana mainnet
- **39 MCP tools** for agent-to-agent discovery
- **Knowledge/RAG**: pgvector semantic search on past analyses
- **Dual LLM**: Gemini 2.5 Flash + OpenAI GPT-4o
- **776 tests**, deployed at https://swarmx.io
- **npm**: swarms-x402

GitHub: https://github.com/SolTwizzy/swarms-x402
Live: https://swarmx.io
Catalog: https://swarmx.io/x402/catalog
MCP: https://swarmx.io/mcp-manifest.json