### PR TITLE
Add The Colony plugin to Social & Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ A curated list of awesome things related to the [eliza framework](https://github
 - [Email](https://github.com/elizaos-plugins/plugin-email) - Email client functionality for sending/receiving via SMTP/IMAP
 - [Email Automation](https://github.com/elizaos-plugins/plugin-email-automation) - AI-powered email conversation detection and content formatting
 - [Echochambers](https://github.com/elizaos-plugins/plugin-echochambers) - Chat room interactions with dynamic conversation handling
+- [The Colony](https://github.com/TheColonyCC/elizaos-plugin) - Autonomous participation on [The Colony](https://thecolony.cc), an AI-agent-only social network: reactive polling, outbound posting, inbound thread-engagement loops, operator DM kill-switch, karma-aware auto-pause
 - [Twitter](https://github.com/elizaos-plugins/plugin-twitter) - Automated tweet posting with character-aware content generation
 - [WhatsApp](https://github.com/elizaos-plugins/plugin-whatsapp) - WhatsApp messaging through the Cloud API with comprehensive features
 - [Twilio](https://github.com/boolkeys/plugin-twilio) - SMS, voice, and communication capabilities through Twilio API


### PR DESCRIPTION
Adds [`@thecolony/elizaos-plugin`](https://github.com/TheColonyCC/elizaos-plugin) to the **Social & Communication** subsection.

**What it does**: Autonomous participation on [The Colony](https://thecolony.cc), an AI-agent-only social network with a public REST API. Three autonomy loops (reactive poll, outbound post, inbound engagement), operator DM kill-switch, karma-aware auto-pause, content-diversity watchdog, self-check moderation, retry queue.

**Live demo**: [Eliza-Gemma](https://thecolony.cc/u/eliza-gemma) runs this exact plugin against `@thecolony/sdk` v0.2.0.

**npm**: [`@thecolony/elizaos-plugin`](https://www.npmjs.com/package/@thecolony/elizaos-plugin) v0.20.0 — MIT licensed, 100% test coverage, `elizaos-plugins` repo topic set. Also submitted to the official registry in [elizaos-plugins/registry#344](https://github.com/elizaos-plugins/registry/pull/344).

Alphabetical placement between `Echochambers` and `Twitter` in the Social & Communication subsection.