### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ A curated list of awesome things related to the [eliza framework](https://github
 - [TrustDB](https://github.com/elizaos-plugins/plugin-trustdb) - Trust scores and performance metrics in a secure database
 - [TrustGo](https://github.com/TrustaLabs/plugin-trustgo) - EVM account information and MEDIA score attestations from TrustGo
 - [Gitcoin Passport](https://github.com/elizaos-plugins/plugin-gitcoin-passport) - Gitcoin Passport API for verifying and managing digital identity
-- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana on-chain agent trust scoring via x402 micropayments. Free preflight + paid Ed25519-signed `twzrd.receipt.v5` trust tokens for elizaOS agents. <1s USDC settlement. [MCP](https://intel.twzrd.xyz/mcp) | [GitHub](https://github.com/twzrd-sol/wzrd-final)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana-native x402 MCP for agent trust scoring and identity verification. 4 free preflight tools score any Solana wallet; paid tools return signed `twzrd.receipt.v5` trust tokens via USDC on Solana (<1s settlement). [MCP](https://intel.twzrd.xyz/mcp)
 
 ### 🔧 Tools & Utilities
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ A curated list of awesome things related to the [eliza framework](https://github
 - [TrustDB](https://github.com/elizaos-plugins/plugin-trustdb) - Trust scores and performance metrics in a secure database
 - [TrustGo](https://github.com/TrustaLabs/plugin-trustgo) - EVM account information and MEDIA score attestations from TrustGo
 - [Gitcoin Passport](https://github.com/elizaos-plugins/plugin-gitcoin-passport) - Gitcoin Passport API for verifying and managing digital identity
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana on-chain agent trust scoring via x402 micropayments. Free preflight + paid Ed25519-signed `twzrd.receipt.v5` trust tokens for elizaOS agents. <1s USDC settlement. [MCP](https://intel.twzrd.xyz/mcp) | [GitHub](https://github.com/twzrd-sol/wzrd-final)
 
 ### 🔧 Tools & Utilities
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Infrastructure & Security** section.

**TWZRD Agent Intel** provides on-chain trust scoring for elizaOS agents operating on Solana:
- Free preflight trust check for any Solana wallet before transacting
- Paid Ed25519-signed `twzrd.receipt.v5` trust receipts via x402 USDC micropayments (<1s)
- MCP server compatible with elizaOS agent architecture
- Enables elizaOS agents to verify counterparty trustworthiness before executing on-chain actions

Fits Infrastructure & Security as it's an identity verification and trust infrastructure layer for Solana-native elizaOS agents.

**Links:** [Website](https://intel.twzrd.xyz) | [MCP](https://intel.twzrd.xyz/mcp) | [GitHub](https://github.com/twzrd-sol/wzrd-final)