### PR TITLE
Add AgentServices — 50+ x402 APIs for AI agents (ElizaOS plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A curated list of awesome things related to the [eliza framework](https://github
 
 ### ⛓️ Blockchain & DeFi
 
+- [AgentServices](https://github.com/vbkotecha/aiservices-api/tree/main/plugins/elizaos) - 50+ x402 paid APIs: crypto prices, DeFi yields, portfolio intelligence, on-chain analytics, market intelligence, and AI inference
 - [0x](https://github.com/elizaos-plugins/plugin-0x) - Token swaps through 0x Protocol across multiple EVM blockchains
 - [Aptos](https://github.com/elizaos-plugins/plugin-aptos) - Token transfers and wallet management on the Aptos blockchain
 - [Arthera](https://github.com/elizaos-plugins/plugin-arthera) - Transactions and token operations on the Arthera network
@@ -176,6 +177,7 @@ A curated list of awesome things related to the [eliza framework](https://github
 
 ### 🧠 AI & Data
 
+- [AgentServices](https://github.com/vbkotecha/aiservices-api/tree/main/plugins/elizaos) - 50+ paid APIs for AI agents via x402 micropayments: crypto data, market intelligence, DeFi strategy, portfolio analysis, on-chain analytics, AI inference, and web search
 - [Allora](https://github.com/elizaos-plugins/plugin-allora) - Real-time AI inferences from Allora Network for market predictions
 - [Asterai](https://github.com/elizaos-plugins/plugin-asterai) - Integration with asterai.io plugins and agents for enhanced AI capabilities
 - [ATTPs](https://github.com/APRO-com/plugin-ATTPs) - Verification of agent activities using proof generation and validation


### PR DESCRIPTION
## AgentServices Plugin for ElizaOS

Adds AgentServices to both **AI & Data** and **Blockchain & DeFi** plugin sections.

### What is AgentServices?

A paid API platform for AI agents — 50 endpoints covering crypto data, market intelligence, on-chain analytics, DeFi strategy, portfolio intelligence, AI inference, and web search. All payments via [x402](https://x402.org) micropayments on Base Mainnet.

### Plugin Features

- **12 actions** (4 free, 8 paid from $0.01-$0.25):
  - Free: crypto prices, fear & greed, trending, news
  - Paid: indicators ($0.02), DeFi yields ($0.02), web search ($0.01), deep research ($0.05), market pulse ($0.05), portfolio intelligence ($0.10), on-chain overview ($0.15), DeFi strategy ($0.25)
- **Market context provider** — passively injects BTC/ETH prices into every turn
- **Auto-pay** via ERC-3009 TransferWithAuthorization (no ETH needed)
- No API keys — agents pay per request in USDC

### Links

- Plugin code: https://github.com/vbkotecha/aiservices-api/tree/main/plugins/elizaos
- API: https://agentservices.to
- Docs: https://agentservices.to/docs
- MCP endpoint: https://agentservices.to/mcp (36 tools)

Similar to the existing AgentData plugin but with 6x more endpoints and a broader catalog (not just crypto — also research, search, inference, on-chain analytics).