### PR TITLE
Add OMNIDEX — non-custodial multichain DEX plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ A curated list of awesome things related to the [eliza framework](https://github
 - [Ankr](https://github.com/elizaos-plugins/plugin-ankr) - Blockchain data queries for wallet information and token analytics
 - [Chainbase](https://github.com/elizaos-plugins/plugin-chainbase) - Natural language interactions with blockchain data across networks
 - [Edwin](https://github.com/elizaos-plugins/plugin-edwin) - Interaction with Edwin tools for DeFi operations
+- [OMNIDEX](https://github.com/mmahdiahamed92-png/omnidex-eliza-plugin) - Non-custodial multichain DEX for AI agents: rug-checked token discovery, best-route quotes, and locally-signed Solana swaps
 
 ### 🧠 AI & Data
 


### PR DESCRIPTION
Adds **OMNIDEX** to Plugins → Crypto Trading & Exchanges.

[omnidex-eliza-plugin](https://github.com/mmahdiahamed92-png/omnidex-eliza-plugin) gives an elizaOS agent a non-custodial multichain DEX:

- **Discover** rug-gated new/trending/graduated tokens
- **Rug-check** any mint (honeypot, authorities, LP lock, holder concentration)
- **Best-route quotes**
- **Swap on Solana** — the agent signs every tx **locally** with its own key; the key never leaves the process

4 actions, keyless discovery, ESM+CJS build. One line, alphabetical-friendly, in the Crypto Trading & Exchanges section.